### PR TITLE
Fix setHomeActions Future Hanging on Flutter

### DIFF
--- a/android/src/main/kotlin/com/shakebugs/flutter/ShakePlugin.kt
+++ b/android/src/main/kotlin/com/shakebugs/flutter/ShakePlugin.kt
@@ -193,6 +193,8 @@ class ShakePlugin : FlutterPlugin, MethodCallHandler, ActivityAware {
         }
 
         Shake.getReportConfiguration().homeActions = actions
+
+        result.success(null)
     }
 
     private fun show(call: MethodCall, result: Result) {


### PR DESCRIPTION
## Summary
Calling `setHomeActions` from Flutter with await causes the execution to hang indefinitely. This happens because the native method channel implementation does not invoke `result.success` after handling the call. As a result, the corresponding Flutter Future is never completed.

This change ensures that `result.success` is properly called on the native side, allowing the Flutter setHomeActions call to complete as expected.